### PR TITLE
Remove unintended placeholder fragments

### DIFF
--- a/app/(personal)/error.tsx
+++ b/app/(personal)/error.tsx
@@ -26,7 +26,7 @@ export default function Error({
         space-y-4 text-pretty text-center"
     >
       <header className="flex flex-col items-center">
-        <ExclamationTriangle className="size-12 " />
+        <ExclamationTriangle className="size-12" />
         <h1 className="text-4xl font-bold lg:text-5xl">
           Something went wrong! <br /> I&apos;m on it!
         </h1>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,9 +18,9 @@ export default function RootLayout({
     <html
       lang="en"
       className={`${blinker.variable} dark scroll-smooth text-pretty
-      font-blinker text-[17px] scrollbar-thin scrollbar-track-neutral-900
-      scrollbar-thumb-neutral-600 hover:scrollbar-thumb-neutral-500
-      active:scrollbar-thumb-sky-500`}
+        font-blinker text-[17px] scrollbar-thin scrollbar-track-neutral-900
+        scrollbar-thumb-neutral-600 hover:scrollbar-thumb-neutral-500
+        active:scrollbar-thumb-sky-500`}
     >
       {/* Empty style tag from gsap */}
       <body

--- a/components/global/Layout/GlobalLayout.tsx
+++ b/components/global/Layout/GlobalLayout.tsx
@@ -11,8 +11,8 @@ export default function GlobalLayout({ children }: Props) {
   return (
     <div
       className={`flex flex-col ${
-        path.startsWith("/chat") ? "h-dvh" : "min-h-dvh"
-      } dark:bg-neutral-900 dark:text-neutral-100`}
+        path.startsWith("/chat") ? "h-dvh" : "min-h-dvh" } dark:bg-neutral-900
+        dark:text-neutral-100`}
     >
       {children}
     </div>

--- a/components/global/Navbar/index.tsx
+++ b/components/global/Navbar/index.tsx
@@ -62,10 +62,7 @@ export function Navbar() {
               aria-label={isHome ? "Scroll to top" : "Go to home page"}
             >
               <Logo
-                className={`size-12 rounded-full ${
-                  !isHome &&
-                  "ΒΘΓΞΙΗΘΑΝΜΕΜΕΘΞΟhover:scale-110 transition-transform"
-                }`}
+                className={`size-12 rounded-full ${!isHome && "transition-transform hover:scale-110"}`}
               />
             </Link>
           </div>

--- a/components/global/Navbar/index.tsx
+++ b/components/global/Navbar/index.tsx
@@ -62,7 +62,8 @@ export function Navbar() {
               aria-label={isHome ? "Scroll to top" : "Go to home page"}
             >
               <Logo
-                className={`size-12 rounded-full ${!isHome && "transition-transform hover:scale-110"}`}
+                className={`size-12 rounded-full ${ !isHome &&
+                  "transition-transform hover:scale-110" }`}
               />
             </Link>
           </div>

--- a/components/pages/chat/ChatMessages.tsx
+++ b/components/pages/chat/ChatMessages.tsx
@@ -49,7 +49,7 @@ export default function ChatMessages({
 
   return (
     <div
-      className="flex-1 space-y-4 overflow-auto pr-4 scrollbar-thin "
+      className="flex-1 space-y-4 overflow-auto pr-4 scrollbar-thin"
       ref={scrollableContainerRef}
     >
       {(messages.length !== 0 || !isTokenLimitReached) && (

--- a/components/shared/CodeBlock.tsx
+++ b/components/shared/CodeBlock.tsx
@@ -59,7 +59,7 @@ export default async function CodeBlock({
                   </span>
                 ) : (
                   <Fragment key={index}>
-                    <span className="inline-flex items-center gap-[2px] ">
+                    <span className="inline-flex items-center gap-[2px]">
                       <FolderSimple weight="duotone" />
                       {name}
                     </span>

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -40,7 +40,7 @@ const sheetVariants = cva(
       side: {
         top: [
           `inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top
-        data-[state=open]:slide-in-from-top`,
+          data-[state=open]:slide-in-from-top`,
         ],
         bottom: [
           `inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom
@@ -48,8 +48,8 @@ const sheetVariants = cva(
         ],
         left: [
           `inset-y-0 left-0 h-full w-3/4 border-r
-        data-[state=closed]:slide-out-to-left
-        data-[state=open]:slide-in-from-left sm:max-w-sm`,
+          data-[state=closed]:slide-out-to-left
+          data-[state=open]:slide-in-from-left sm:max-w-sm`,
         ],
         right: [
           `inset-y-0 right-0 h-full w-3/4 border-l-2

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "eslint-config-prettier": "^9.1.0",
     "postcss": "8.4.38",
     "prettier": "3.2.5",
-    "prettier-plugin-classnames": "^0.6.5",
+    "prettier-plugin-classnames": "^0.7.0",
     "prettier-plugin-tailwindcss": "0.5.13",
     "shiki": "^1.2.4",
     "tailwindcss": "3.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,8 +218,8 @@ devDependencies:
     specifier: 3.2.5
     version: 3.2.5
   prettier-plugin-classnames:
-    specifier: ^0.6.5
-    version: 0.6.5(prettier@3.2.5)
+    specifier: ^0.7.0
+    version: 0.7.0(prettier@3.2.5)
   prettier-plugin-tailwindcss:
     specifier: 0.5.13
     version: 0.5.13(@ianvs/prettier-plugin-sort-imports@4.2.1)(prettier@3.2.5)
@@ -9549,6 +9549,8 @@ packages:
     resolution: {integrity: sha512-Un1yLbSlk/zfwrltgguskExIioXZlFSFwsyXU0cnBorLywbTbcdzmJJEebh+U2cFCtR7y8nDs5lPHAe7ldxjZg==}
     engines: {node: '>=18.12.1', npm: '>=8.19.2'}
     hasBin: true
+    dependencies:
+      '@xmldom/xmldom': 0.8.10
     dev: false
     bundledDependencies:
       - '@xmldom/xmldom'
@@ -9896,14 +9898,17 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-classnames@0.6.5(prettier@3.2.5):
-    resolution: {integrity: sha512-33RQaTSxz4KzITJSJCOTTrVwbmuGjz4wIpJbDFalHQ8EBK4p0/4rgkvHd4M1MSTG/5gsfZUBksQRHBLYkuLv0Q==}
+  /prettier-plugin-classnames@0.7.0(prettier@3.2.5):
+    resolution: {integrity: sha512-gxnMyTUPs5rPY/JzjLBsiBFA0Dj9/oukk02fGofAQ+FFzGYNZEHWL8Q9TWXmglgJgBzy2Cx0Az9n+Uk4DtianA==}
     engines: {node: '>=14'}
     peerDependencies:
       prettier: ^2 || ^3
       prettier-plugin-astro: '*'
+      prettier-plugin-svelte: '*'
     peerDependenciesMeta:
       prettier-plugin-astro:
+        optional: true
+      prettier-plugin-svelte:
         optional: true
     dependencies:
       prettier: 3.2.5


### PR DESCRIPTION
Hello! I often check the use cases of prettier-plugin-classnames, and one day while looking through this repository, I found a bug in the `components/global/Navbar/index.tsx` change in commit 9e1bdd9.

At the time, I was working towards the release of `v0.7.0`, so I couldn't afford to report this or fix it myself, but yesterday I finally released `v0.7.0` and am sending this PR.